### PR TITLE
chore: Remove Stock validation for registering HH

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
@@ -886,16 +886,16 @@ class _CustomSearchBeneficiaryPageState
                             i18_local
                                 .beneficiaryDetails.insufficientStockMessage);
 
-                        if (spaq1 == 0) {
+                        /* if (spaq1 == 0) {
                           descriptionText +=
                               "\n ${localizations.translate(i18_local.beneficiaryDetails.spaq1DoseUnit)}";
                         }
                         if (spaq2 == 0) {
                           descriptionText +=
                               "\n ${localizations.translate(i18_local.beneficiaryDetails.spaq2DoseUnit)}";
-                        }
+                        } */
 
-                        if ((spaq1 > 0 || spaq2 > 0)) {
+                        //if ((spaq1 > 0 || spaq2 > 0)) {
                           FocusManager.instance.primaryFocus?.unfocus();
                           context.read<DigitScannerBloc>().add(
                                 const DigitScannerEvent.handleScanner(),
@@ -911,7 +911,7 @@ class _CustomSearchBeneficiaryPageState
                           customSearchHouseholdsBloc.add(
                             const SearchHouseholdsClearEvent(),
                           );
-                        } else {
+                        /* } else {
                           showCustomPopup(
                             context: context,
                             builder: (popupContext) => Popup(
@@ -939,7 +939,7 @@ class _CustomSearchBeneficiaryPageState
                               ],
                             ),
                           );
-                        }
+                        } */
                       },
                     );
                   },


### PR DESCRIPTION
Includes a fix for removing the stock quantity validation when registering a Household. User is now able to register HHs without managing the stock.